### PR TITLE
Bump patch version to 1.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-snippets"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
     { name="CyberOtter", email="contact@betonquest.org" },
 ]


### PR DESCRIPTION
Just bumping patch version in `pyproject.toml` file. Hopefully this will trigger PyPi to update this listing https://pypi.org/project/mkdocs-snippets/ and then hopefully when I run `pip install` requirements on my local machine / build pipeline, it will find latest version of `main` branch. 