### PR TITLE
Pass page.url to relativize_links() for consistent value when `site_url` not configured

### DIFF
--- a/src/mkdocs_snippets/plugin.py
+++ b/src/mkdocs_snippets/plugin.py
@@ -80,7 +80,7 @@ class Snippets(BasePlugin[SnippetPluginConfig]):
 
                 snippet_content = self.snippets[snippet_address][snippet_id]
 
-                snippet_content = relativize_links(snippet_content, page.file.src_uri, snippet_id)
+                snippet_content = relativize_links(snippet_content, page.url, snippet_id)
 
                 snippet_content = self.preserve_indentation(snippet_content, markdown)
 
@@ -117,6 +117,10 @@ markdown_link_pattern = re.compile(r"\[(.*)\]\((.*(#.*)?)\)")
 
 
 def relativize_links(snippet_content, current_path, snippet_id) -> str:
+    current_path = '/' + current_path.strip('/') + '/'
+    current_path_without_filename = current_path.rsplit("/", 2)[0]
+    current_path_without_filename = remove_mike_version_from_path(current_path_without_filename)
+
     matches = re.findall(markdown_link_pattern, snippet_content)
     for match in matches:
         link_text = match[0]
@@ -140,10 +144,6 @@ def relativize_links(snippet_content, current_path, snippet_id) -> str:
 
         link_without_filetype = link_and_filetype[0]
         filetype = link_and_filetype[1]
-
-        current_path_without_filename = current_path.rsplit("/", 2)[0]
-
-        current_path_without_filename = remove_mike_version_from_path(current_path_without_filename)
 
         relative_link = os.path.relpath(f"docs/{link_without_filetype}", f"docs/{current_path_without_filename}")
 

--- a/src/mkdocs_snippets/plugin.py
+++ b/src/mkdocs_snippets/plugin.py
@@ -80,7 +80,7 @@ class Snippets(BasePlugin[SnippetPluginConfig]):
 
                 snippet_content = self.snippets[snippet_address][snippet_id]
 
-                snippet_content = relativize_links(snippet_content, page.abs_url, snippet_id)
+                snippet_content = relativize_links(snippet_content, page.file.src_uri, snippet_id)
 
                 snippet_content = self.preserve_indentation(snippet_content, markdown)
 
@@ -141,11 +141,7 @@ def relativize_links(snippet_content, current_path, snippet_id) -> str:
         link_without_filetype = link_and_filetype[0]
         filetype = link_and_filetype[1]
 
-        if current_path is None:
-            # The docs are hosted in the root
-            current_path_without_filename = ''
-        else:
-            current_path_without_filename = current_path.rsplit("/", 2)[0]
+        current_path_without_filename = current_path.rsplit("/", 2)[0]
 
         current_path_without_filename = remove_mike_version_from_path(current_path_without_filename)
 


### PR DESCRIPTION
I observed that links in snippets would be generated correctly when using `mkdocs serve` locally, but if you ran `mkdocs build` to make the static HTML files, the links were missing their relative path prefixes (eg. `../`). 

After some debugging I noticed that when the `site_url` property is not set in `mkdocs.yml`, the value of `page.abs_url` differs between the 2 commands; it is `None` when running `build`, but it is a string path when running `serve`.  _(Note: If `site_url` is set in `mkdocs.yml`, `page.abs_url` is the same across both these commands)._ 

This means that when I raised https://github.com/BetonQuest/mkdocs-snippets/pull/7 a couple of weeks ago which added handling for `current_path` variable being empty I was actually not fixing the root cause of the problem. 

This PR changes it to use `page.url` which I have observed being consistent between the 2 commands, regardless of if `site_url` is or is not set in `mkdocs.yml`

Sadly, I cannot contribute tests to cover all the logic in `relativize_links()` because I do not know the expected behaviour of functions like `remove_mike_version_from_path()`. 