### PR TITLE
fix: handle multiple snippets in one line

### DIFF
--- a/src/mkdocs_snippets/plugin.py
+++ b/src/mkdocs_snippets/plugin.py
@@ -36,7 +36,12 @@ class Snippets(BasePlugin[SnippetPluginConfig]):
     def on_config(self, config: MkDocsConfig) -> None:
         self.snippet_syntax_start = self.config.delimiter + self.config.identifier + self.config.divider_char
         self.snippet_syntax_pattern = re.compile(
-            f"{self.snippet_syntax_start}(.*){self.config.divider_char}(.*){self.config.delimiter}")
+            self.snippet_syntax_start
+            + f"([^{self.config.divider_char}]+)"
+            + self.config.divider_char
+            + f"([^{self.config.delimiter}]+)"
+            + self.config.delimiter
+        )
 
     # Builds a snippet index based on all files in the snippets_directory
     def on_files(self, files: Files, *, config: MkDocsConfig) -> Optional[Files]:


### PR DESCRIPTION
Currently, if you have 2 snippets in the same line, the plugin will fail. This will fail for example:

```markdown
@Snippet:file:snippet1@ @Snippet:file:snippet2@
```

With error ...

```
tried to load a snippet from the non-existent file 'snippets/file:snippet1@ @Snippet:file.yml'!
```

This PR fixes that issue by adjusting the regex slightly.